### PR TITLE
feat: make token cache directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ZOHO_CLIENT_ID=your_zoho_client_id
 ZOHO_CLIENT_SECRET=your_zoho_client_secret  
 ZOHO_REFRESH_TOKEN=your_zoho_refresh_token
 ZOHO_STORE_ID=your_zoho_store_id
+CACHE_DIR=/tmp # optional cache directory (use /tmp on serverless)
 ```
 
 ## Deployment
@@ -39,6 +40,7 @@ This project is optimized for Cloudflare Pages:
 2. Set build command: `npm run build`
 3. Set output directory: `out`
 4. Add environment variables in Cloudflare Pages dashboard
+   - Set `CACHE_DIR` to `/tmp` or another writable path on serverless platforms
 
 ## Project Structure
 

--- a/src/lib/token-persistence.ts
+++ b/src/lib/token-persistence.ts
@@ -1,0 +1,46 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+const DATA_DIR = process.env.CACHE_DIR || path.join(os.tmpdir(), '.cache');
+const memoryCache = new Map<string, string>();
+let directoryUsable = true;
+
+async function ensureDir() {
+  if (!directoryUsable) return;
+  try {
+    await fs.mkdir(DATA_DIR, { recursive: true });
+  } catch (err) {
+    directoryUsable = false;
+    console.warn(`Token persistence disabled: unable to create ${DATA_DIR}`, err);
+  }
+}
+
+export async function saveToken(key: string, token: string): Promise<void> {
+  memoryCache.set(key, token);
+  await ensureDir();
+  if (!directoryUsable) return;
+  try {
+    await fs.writeFile(path.join(DATA_DIR, key), token, 'utf8');
+  } catch (err) {
+    directoryUsable = false;
+    console.warn(`Token persistence disabled: unable to write to ${DATA_DIR}`, err);
+  }
+}
+
+export async function loadToken(key: string): Promise<string | null> {
+  if (memoryCache.has(key)) {
+    return memoryCache.get(key)!;
+  }
+  await ensureDir();
+  if (!directoryUsable) {
+    return null;
+  }
+  try {
+    const token = await fs.readFile(path.join(DATA_DIR, key), 'utf8');
+    memoryCache.set(key, token);
+    return token;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/token-persistence.ts
+++ b/src/lib/token-persistence.ts
@@ -44,3 +44,14 @@ export async function loadToken(key: string): Promise<string | null> {
     return null;
   }
 }
+
+export async function deleteToken(key: string): Promise<void> {
+  memoryCache.delete(key);
+  await ensureDir();
+  if (!directoryUsable) return;
+  try {
+    await fs.unlink(path.join(DATA_DIR, key));
+  } catch {
+    // ignore errors removing token
+  }
+}


### PR DESCRIPTION
## Summary
- allow token cache directory to be configured via `CACHE_DIR`
- fall back to in-memory token cache if persistent directory cannot be created
- document `CACHE_DIR` and recommend `/tmp` for serverless deployments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688e6b64b96883249da64ef3d211a960