### PR TITLE
feat: add redis product cache and manual sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lucide-react": "^0.294.0",
     "clsx": "^2.0.0",
     "tailwind-merge": "^2.0.0",
-    "@vercel/analytics": "^1.1.1"
+    "@vercel/analytics": "^1.1.1",
+    "@upstash/redis": "^1.30.5"
   },
   "devDependencies": {
     "typescript": "^5.3.2",

--- a/src/lib/redis-product-service.js
+++ b/src/lib/redis-product-service.js
@@ -1,0 +1,471 @@
+import { Redis } from '@upstash/redis'
+import { zohoInventoryAPI } from './zoho-api-inventory'
+
+// Initialize Redis with existing environment variables
+const redis = new Redis({
+  url: process.env.KV_REST_API_URL,
+  token: process.env.KV_REST_API_TOKEN,
+})
+
+export class RedisProductService {
+  // Cache keys
+  static KEYS = {
+    ALL_PRODUCTS: 'products:all',
+    LAST_SYNC: 'products:last_sync',
+    PRODUCT_BY_ID: (id) => `product:${id}`,
+    PRODUCT_BY_SKU: (sku) => `product:sku:${sku}`,
+    PRODUCT_IMAGE: (id) => `product:image:${id}`,
+    SYNC_STATUS: 'sync:status',
+  }
+
+  // Cache TTL (24 hours)
+  static TTL = 86400
+
+  /**
+   * Get all products from Redis cache
+   */
+  async getAllProducts() {
+    try {
+      console.log('🔍 Checking Redis cache for products...')
+
+      const cached = await redis.get(RedisProductService.KEYS.ALL_PRODUCTS)
+      if (cached) {
+        const products = typeof cached === 'string' ? JSON.parse(cached) : cached
+        console.log(`✅ Found ${products.length} products in Redis cache`)
+        return products
+      }
+
+      console.log('⚠️ Cache miss - attempting emergency sync...')
+      return await this.emergencySync()
+    } catch (error) {
+      console.error('❌ Redis error, falling back to direct API:', error)
+      return await this.fetchFromInventoryDirectly()
+    }
+  }
+
+  /**
+   * Get single product by ID
+   */
+  async getProductById(itemId) {
+    try {
+      const cached = await redis.get(RedisProductService.KEYS.PRODUCT_BY_ID(itemId))
+      if (cached) {
+        return typeof cached === 'string' ? JSON.parse(cached) : cached
+      }
+
+      const allProducts = await this.getAllProducts()
+      return allProducts.find((p) => p.item_id === itemId || p.product_id === itemId)
+    } catch (error) {
+      console.error('Error fetching product by ID:', error)
+      return null
+    }
+  }
+
+  /**
+   * Get product by SKU
+   */
+  async getProductBySku(sku) {
+    try {
+      const cached = await redis.get(RedisProductService.KEYS.PRODUCT_BY_SKU(sku))
+      if (cached) {
+        return typeof cached === 'string' ? JSON.parse(cached) : cached
+      }
+
+      const allProducts = await this.getAllProducts()
+      return allProducts.find((p) => p.sku === sku)
+    } catch (error) {
+      console.error('Error fetching product by SKU:', error)
+      return null
+    }
+  }
+
+  /**
+   * Get cached product image data
+   */
+  async getProductImage(itemId) {
+    try {
+      const cached = await redis.get(RedisProductService.KEYS.PRODUCT_IMAGE(itemId))
+      if (cached) {
+        return typeof cached === 'string' ? JSON.parse(cached) : cached
+      }
+      return null
+    } catch (error) {
+      console.error('Error fetching cached image:', error)
+      return null
+    }
+  }
+
+  /**
+   * Sync products from Zoho Inventory API only - SIMPLIFIED
+   */
+  async syncProducts() {
+    try {
+      console.log('🔄 Starting product sync from Zoho Inventory API...')
+
+      // Set sync status
+      await redis.setex(
+        RedisProductService.KEYS.SYNC_STATUS,
+        300,
+        JSON.stringify({
+          status: 'syncing',
+          started_at: new Date().toISOString(),
+        })
+      )
+
+      // Step 1: Get ALL products from Inventory API
+      console.log('📦 Fetching products from Zoho Inventory API...')
+      const inventoryProducts = await zohoInventoryAPI.getInventoryProducts()
+      console.log(`✅ Retrieved ${inventoryProducts.length} total inventory products`)
+
+      // Step 2: Filter by cf_display_in_app custom field
+      console.log('🔍 Filtering products by cf_display_in_app field...')
+      const filteredProducts = this.filterProductsByDisplayInApp(inventoryProducts)
+      console.log(`✅ Found ${filteredProducts.length} products with display_in_app=true`)
+
+      // Step 3: Download and cache product images
+      console.log('🖼️ Processing product images...')
+      await this.cacheProductImages(filteredProducts)
+
+      // Step 4: Transform to expected frontend format
+      console.log('🎨 Transforming products to frontend format...')
+      const transformedProducts = this.transformInventoryProducts(filteredProducts)
+
+      // Step 5: Filter out inactive products
+      const activeProducts = transformedProducts.filter(
+        (product) => product.status === 'active' || product.status === 'Active' || !product.status
+      )
+
+      console.log(`✅ Final result: ${activeProducts.length} active products ready for cache`)
+
+      // Store in Redis with multiple access patterns
+      const promises = []
+
+      // Store all products
+      promises.push(
+        redis.setex(
+          RedisProductService.KEYS.ALL_PRODUCTS,
+          RedisProductService.TTL,
+          JSON.stringify(activeProducts)
+        )
+      )
+
+      // Store individual products for fast lookups
+      activeProducts.forEach((product) => {
+        promises.push(
+          redis.setex(
+            RedisProductService.KEYS.PRODUCT_BY_ID(product.item_id || product.product_id),
+            RedisProductService.TTL,
+            JSON.stringify(product)
+          )
+        )
+
+        if (product.sku) {
+          promises.push(
+            redis.setex(
+              RedisProductService.KEYS.PRODUCT_BY_SKU(product.sku),
+              RedisProductService.TTL,
+              JSON.stringify(product)
+            )
+          )
+        }
+      })
+
+      // Store sync metadata
+      promises.push(
+        redis.setex(
+          RedisProductService.KEYS.LAST_SYNC,
+          RedisProductService.TTL,
+          Date.now()
+        )
+      )
+
+      // Update sync status
+      promises.push(
+        redis.setex(
+          RedisProductService.KEYS.SYNC_STATUS,
+          300,
+          JSON.stringify({
+            status: 'completed',
+            completed_at: new Date().toISOString(),
+            product_count: activeProducts.length,
+          })
+        )
+      )
+
+      await Promise.all(promises)
+
+      console.log(`🎉 Product sync completed successfully - ${activeProducts.length} products cached`)
+
+      return {
+        success: true,
+        productCount: activeProducts.length,
+        timestamp: new Date().toISOString(),
+      }
+    } catch (error) {
+      console.error('❌ Product sync failed:', error)
+
+      // Set error status
+      await redis.setex(
+        RedisProductService.KEYS.SYNC_STATUS,
+        300,
+        JSON.stringify({
+          status: 'failed',
+          error: error.message,
+          failed_at: new Date().toISOString(),
+        })
+      )
+
+      throw error
+    }
+  }
+
+  /**
+   * Cache product images from Inventory API
+   */
+  async cacheProductImages(products) {
+    const imagePromises = []
+
+    for (const product of products) {
+      if (product.image_id) {
+        // Cache image metadata and URL for proxy endpoint
+        const imageData = {
+          item_id: product.item_id,
+          image_id: product.image_id,
+          image_name: product.image_name,
+          image_type: product.image_type,
+          proxy_url: `/api/images/${product.item_id}`, // Your existing image proxy
+          cached_at: Date.now(),
+        }
+
+        imagePromises.push(
+          redis.setex(
+            RedisProductService.KEYS.PRODUCT_IMAGE(product.item_id),
+            RedisProductService.TTL,
+            JSON.stringify(imageData)
+          )
+        )
+      }
+    }
+
+    if (imagePromises.length > 0) {
+      await Promise.all(imagePromises)
+      console.log(`✅ Cached ${imagePromises.length} product images`)
+    }
+  }
+
+  /**
+   * Emergency sync - when cache is empty
+   */
+  async emergencySync() {
+    try {
+      console.log('🚨 Emergency sync triggered')
+      await this.syncProducts()
+      return await this.getAllProducts()
+    } catch (error) {
+      console.error('❌ Emergency sync failed, falling back to direct API')
+      return await this.fetchFromInventoryDirectly()
+    }
+  }
+
+  /**
+   * Direct Inventory API fallback (no caching)
+   */
+  async fetchFromInventoryDirectly() {
+    try {
+      console.log('🔄 Fetching products directly from Zoho Inventory API (no cache)')
+
+      const inventoryProducts = await zohoInventoryAPI.getInventoryProducts()
+      const filteredProducts = this.filterProductsByDisplayInApp(inventoryProducts)
+      const transformedProducts = this.transformInventoryProducts(filteredProducts)
+
+      return transformedProducts.filter(
+        (product) => product.status === 'active' || product.status === 'Active' || !product.status
+      )
+    } catch (error) {
+      console.error('❌ Direct API fallback failed:', error)
+      return []
+    }
+  }
+
+  /**
+   * Get cache statistics
+   */
+  async getCacheStats() {
+    try {
+      const [lastSync, syncStatus, productCount] = await Promise.all([
+        redis.get(RedisProductService.KEYS.LAST_SYNC),
+        redis.get(RedisProductService.KEYS.SYNC_STATUS),
+        redis.get(RedisProductService.KEYS.ALL_PRODUCTS),
+      ])
+
+      const products = productCount
+        ? typeof productCount === 'string'
+          ? JSON.parse(productCount)
+          : productCount
+        : []
+      const status = syncStatus
+        ? typeof syncStatus === 'string'
+          ? JSON.parse(syncStatus)
+          : syncStatus
+        : null
+
+      return {
+        lastSync: lastSync ? new Date(lastSync) : null,
+        productCount: Array.isArray(products) ? products.length : 0,
+        cacheAge: lastSync ? Date.now() - lastSync : null,
+        syncStatus: status,
+        healthy: Array.isArray(products) && products.length > 0,
+        apiSource: 'inventory_only',
+      }
+    } catch (error) {
+      return {
+        error: error.message,
+        healthy: false,
+        apiSource: 'inventory_only',
+      }
+    }
+  }
+
+  // === SIMPLIFIED PRODUCT PROCESSING (INVENTORY ONLY) ===
+
+  /**
+   * Filter products by cf_display_in_app custom field
+   */
+  filterProductsByDisplayInApp(inventoryProducts) {
+    return inventoryProducts.filter((product) => {
+      if (!product.custom_fields || !Array.isArray(product.custom_fields)) {
+        return false
+      }
+
+      const displayField = product.custom_fields.find((field) => {
+        const fieldLabel = field.label?.toLowerCase()
+        const fieldName = field.field_name?.toLowerCase()
+
+        return (
+          fieldLabel === 'display_in_app' ||
+          fieldName === 'display_in_app' ||
+          fieldLabel === 'cf_display_in_app' ||
+          fieldName === 'cf_display_in_app'
+        )
+      })
+
+      if (!displayField) return false
+
+      return (
+        displayField.value === true ||
+        displayField.value === 'true' ||
+        displayField.value === '1' ||
+        displayField.value === 1
+      )
+    })
+  }
+
+  /**
+   * Transform Inventory products to frontend format (NO MERGING NEEDED)
+   */
+  transformInventoryProducts(inventoryProducts) {
+    return inventoryProducts.map((item) => {
+      // Extract images from Inventory API data
+      const images = []
+
+      // Primary image (use your existing proxy endpoint)
+      if (item.image_id) {
+        images.push(`/api/images/${item.item_id}`)
+      }
+
+      // Document images from Inventory API
+      if (item.documents && Array.isArray(item.documents)) {
+        item.documents.forEach((doc) => {
+          if (
+            doc.file_type &&
+            ['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(doc.file_type.toLowerCase())
+          ) {
+            if (doc.file_url) images.push(doc.file_url)
+            else if (doc.download_url) images.push(doc.download_url)
+          }
+        })
+      }
+
+      // Get custom field value helper
+      const getCustomFieldValue = (fieldName) => {
+        if (!item.custom_fields || !Array.isArray(item.custom_fields)) {
+          return null
+        }
+
+        const field = item.custom_fields.find((f) => {
+          const label = f.label?.toLowerCase()
+          const name = f.field_name?.toLowerCase()
+          const target = fieldName.toLowerCase()
+
+          return (
+            label === target ||
+            name === target ||
+            label === `cf_${target}` ||
+            name === `cf_${target}`
+          )
+        })
+
+        return field ? field.value : null
+      }
+
+      return {
+        // Core product data
+        product_id: item.item_id,
+        item_id: item.item_id,
+        product_name: item.name,
+        name: item.name,
+        product_price: item.rate || item.min_rate || 0,
+        rate: item.rate || 0,
+        product_description: item.description || '',
+        description: item.description || '',
+        sku: item.sku,
+        status: item.status || 'active',
+
+        // Inventory data
+        inventory_count: this.parseStock(item.stock_on_hand),
+        stock_on_hand: item.stock_on_hand,
+        available_stock: item.available_stock,
+
+        // Category data
+        product_category: item.category_name || item.group_name || '',
+        category_name: item.category_name,
+        category_id: item.category_id,
+        group_name: item.group_name,
+
+        // Images (all from Inventory API)
+        product_images: images,
+        image_id: item.image_id,
+        image_name: item.image_name,
+        image_type: item.image_type,
+
+        // Custom fields
+        cf_display_in_app: getCustomFieldValue('display_in_app'),
+        custom_fields: item.custom_fields,
+
+        // SEO
+        seo_url: item.sku || item.item_id,
+        url: item.sku || item.item_id,
+
+        // Timestamps
+        created_time: item.created_time,
+        last_modified_time: item.last_modified_time,
+
+        // Data source indicator
+        data_source: 'inventory_api_only',
+      }
+    })
+  }
+
+  /**
+   * Parse stock values
+   */
+  parseStock(stockValue) {
+    if (!stockValue) return 0
+    const parsed = typeof stockValue === 'string' ? parseFloat(stockValue) : Number(stockValue)
+    return isNaN(parsed) ? 0 : parsed
+  }
+}
+
+// Create and export the service instance
+export const productService = new RedisProductService()
+

--- a/src/lib/redis-product-service.js
+++ b/src/lib/redis-product-service.js
@@ -333,6 +333,19 @@ export class RedisProductService {
    */
   filterProductsByDisplayInApp(inventoryProducts) {
     return inventoryProducts.filter((product) => {
+      // First check if the custom field exists as a top-level property (cf_display_in_app)
+      const topLevelValue =
+        product.cf_display_in_app ?? product.cf_display_in_app_unformatted
+      if (topLevelValue !== undefined) {
+        return (
+          topLevelValue === true ||
+          topLevelValue === 'true' ||
+          topLevelValue === '1' ||
+          topLevelValue === 1
+        )
+      }
+
+      // Fallback to searching within the custom_fields array
       if (!product.custom_fields || !Array.isArray(product.custom_fields)) {
         return false
       }
@@ -408,6 +421,9 @@ export class RedisProductService {
         return field ? field.value : null
       }
 
+      const displayInAppValue =
+        item.cf_display_in_app ?? getCustomFieldValue('display_in_app')
+
       return {
         // Core product data
         product_id: item.item_id,
@@ -439,7 +455,7 @@ export class RedisProductService {
         image_type: item.image_type,
 
         // Custom fields
-        cf_display_in_app: getCustomFieldValue('display_in_app'),
+        cf_display_in_app: displayInAppValue,
         custom_fields: item.custom_fields,
 
         // SEO

--- a/src/lib/zoho-api-inventory.ts
+++ b/src/lib/zoho-api-inventory.ts
@@ -153,7 +153,10 @@ class ZohoInventoryAPI {
     try {
       console.log('📦 Fetching products from Zoho Inventory API...');
       
-      const response = await this.apiRequest('/items');
+      // Request documents and custom field data for each item
+      const response = await this.apiRequest(
+        '/items?custom_fields=true&include=documents'
+      );
       const items = response.items || [];
       
       console.log(`📊 Retrieved ${items.length} items from Inventory API`);

--- a/src/lib/zoho-api-inventory.ts
+++ b/src/lib/zoho-api-inventory.ts
@@ -154,9 +154,19 @@ class ZohoInventoryAPI {
       console.log('📦 Fetching products from Zoho Inventory API...');
       
       // Request documents and custom field data for each item
-      const response = await this.apiRequest(
-        '/items?custom_fields=true&include=documents'
-      );
+      // Some accounts may not support the custom_fields=true parameter, so
+      // we attempt the call and gracefully fall back if Zoho rejects it.
+      let response;
+      try {
+        response = await this.apiRequest('/items?custom_fields=true&include=documents');
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('Invalid value passed for custom_fields')) {
+          console.warn('custom_fields=true not supported, retrying without it');
+          response = await this.apiRequest('/items?include=documents');
+        } else {
+          throw err;
+        }
+      }
       const items = response.items || [];
       
       console.log(`📊 Retrieved ${items.length} items from Inventory API`);

--- a/src/pages/api/cache-status.js
+++ b/src/pages/api/cache-status.js
@@ -1,0 +1,61 @@
+import { productService } from '../../lib/redis-product-service'
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    const stats = await productService.getCacheStats()
+
+    const cacheHealth = {
+      healthy: stats.healthy,
+      status: stats.healthy ? 'healthy' : 'unhealthy',
+      lastSync: stats.lastSync,
+      cacheAge: stats.cacheAge,
+      cacheAgeHours: stats.cacheAge
+        ? Math.round((stats.cacheAge / (1000 * 60 * 60)) * 100) / 100
+        : null,
+      productCount: stats.productCount,
+      syncStatus: stats.syncStatus,
+      apiSource: 'inventory_only',
+      benefits: [
+        '🚀 No Storefront API rate limits',
+        '⚡ Single API source (faster sync)',
+        '🖼️ Images via Inventory API + proxy',
+        '💾 All data cached in Redis',
+      ],
+      recommendations: [],
+    }
+
+    if (!stats.healthy) {
+      cacheHealth.recommendations.push('❌ Cache is unhealthy - run manual sync')
+    }
+
+    if (stats.cacheAge && stats.cacheAge > 25 * 60 * 60 * 1000) {
+      cacheHealth.recommendations.push('⚠️ Cache is stale - consider running sync')
+    }
+
+    if (stats.productCount === 0) {
+      cacheHealth.recommendations.push('❌ No products in cache - run sync immediately')
+    }
+
+    if (stats.productCount > 0 && stats.cacheAge < 2 * 60 * 60 * 1000) {
+      cacheHealth.recommendations.push('✅ Cache is fresh and healthy (Inventory API only)')
+    }
+
+    return res.json({
+      ...cacheHealth,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('Cache status error:', error)
+    return res.status(500).json({
+      error: 'Failed to get cache status',
+      details: error.message,
+      healthy: false,
+      timestamp: new Date().toISOString(),
+    })
+  }
+}
+

--- a/src/pages/api/cron/sync-products.js
+++ b/src/pages/api/cron/sync-products.js
@@ -1,0 +1,34 @@
+import { productService } from '../../../lib/redis-product-service'
+
+export default async function handler(req, res) {
+  if (req.headers.authorization !== `Bearer ${process.env.CRON_SECRET}`) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    console.log('🔄 Starting scheduled product sync (Inventory API only)...')
+
+    const result = await productService.syncProducts()
+
+    console.log(`✅ Scheduled sync completed: ${result.productCount} products`)
+
+    return res.json({
+      success: true,
+      ...result,
+      message: 'Products synced successfully from Inventory API only',
+      api_source: 'inventory_only',
+    })
+  } catch (error) {
+    console.error('❌ Scheduled product sync failed:', error)
+    return res.status(500).json({
+      error: error.message,
+      success: false,
+      timestamp: new Date().toISOString(),
+    })
+  }
+}
+

--- a/src/pages/api/products.js
+++ b/src/pages/api/products.js
@@ -1,311 +1,44 @@
-// ===== src/pages/api/products.js ===== (FIXED WITH STOREFRONT API IMAGES)
-import { zohoInventoryAPI } from '../../lib/zoho-api-inventory';
-import { zohoAPI } from '../../lib/zoho-api.ts';
+import { productService } from '../../lib/redis-product-service'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    return res.status(405).json({ error: 'Method not allowed' })
   }
 
   try {
-    console.log('🚀 Starting FIXED products API with Storefront images...');
-    
-    const startTime = Date.now();
+    console.log('🚀 Loading products from Redis cache (Inventory API source)...')
 
-    // Step 1: Get products from Inventory API (has custom fields)
-    console.log('📦 Fetching products from Zoho Inventory API...');
-    const inventoryProducts = await zohoInventoryAPI.getInventoryProducts();
-    console.log(`✅ Retrieved ${inventoryProducts.length} total inventory products`);
+    const startTime = Date.now()
+    const products = await productService.getAllProducts()
+    const processingTime = Date.now() - startTime
 
-    // Step 2: Get products from Commerce API with FIXED Storefront images
-    console.log('🖼️ Fetching products from FIXED Zoho Commerce API (Storefront + Store)...');
-    const commerceProducts = await zohoAPI.getProducts(); // Now uses both Store + Storefront APIs
-    console.log(`✅ Retrieved ${commerceProducts.length} commerce products with fixed images`);
+    console.log(`✅ Products API completed in ${processingTime}ms`)
+    console.log(`📊 Serving ${products.length} products from cache`)
 
-    // Step 3: Filter inventory products by cf_display_in_app custom field
-    console.log('🔍 Filtering products by cf_display_in_app field...');
-    const filteredProducts = filterProductsByDisplayInApp(inventoryProducts);
-    console.log(`✅ Found ${filteredProducts.length} products with display_in_app=true`);
+    res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=86400')
 
-    // Step 4: Merge inventory products with commerce images (now using Storefront API)
-    console.log('🔄 Merging inventory products with FIXED commerce images...');
-    const mergedProducts = mergeInventoryWithCommerceImages(filteredProducts, commerceProducts);
-
-    // Step 5: Transform to expected frontend format
-    console.log('🎨 Transforming products to frontend format...');
-    const transformedProducts = transformProducts(mergedProducts);
-
-    // Step 6: Filter out inactive products
-    const activeProducts = transformedProducts.filter(product => 
-      product.status === 'active' || product.status === 'Active' || !product.status
-    );
-
-    const processingTime = Date.now() - startTime;
-    console.log(`✅ FIXED Products API completed in ${processingTime}ms`);
-
-    // Provide detailed statistics
-    const imageStats = generateImageStatistics(activeProducts);
-
-    res.status(200).json({ 
-      products: activeProducts,
+    return res.json({
+      success: true,
+      products: products,
       meta: {
-        total_inventory_products: inventoryProducts.length,
-        display_in_app_products: filteredProducts.length,
-        active_display_products: activeProducts.length,
-        commerce_products_fetched: commerceProducts.length,
+        total_products: products.length,
+        cached: true,
         processing_time_ms: processingTime,
         timestamp: new Date().toISOString(),
-        api_version: '2.0_fixed_storefront_images',
-        fix_applied: 'storefront_api_integration',
-        ...imageStats
-      }
-    });
-
+        source: 'redis_cache',
+        api_source: 'inventory_only',
+        no_storefront_api: true,
+      },
+    })
   } catch (error) {
-    console.error('❌ FIXED Products API Error:', {
-      message: error.message,
-      stack: error.stack,
-      name: error.name
-    });
-    
-    res.status(500).json({ 
-      error: 'Failed to fetch products',
+    console.error('❌ Products API Error:', error)
+
+    return res.status(500).json({
+      error: 'Failed to load products',
       details: error.message,
       timestamp: new Date().toISOString(),
-      errorType: error.name,
-      api_version: '2.0_fixed_storefront_images',
-      stack: process.env.NODE_ENV === 'development' ? error.stack : undefined
-    });
+      success: false,
+    })
   }
 }
 
-/**
- * Filter products based on cf_display_in_app custom field
- */
-function filterProductsByDisplayInApp(products) {
-  console.log(`🔍 Filtering ${products.length} products for display_in_app=true`);
-  
-  return products.filter(product => {
-    // Handle both formatted and unformatted custom field values
-    const displayInAppString = product.cf_display_in_app;
-    const displayInAppBoolean = product.cf_display_in_app_unformatted;
-    
-    const isDisplayInApp = 
-      displayInAppBoolean === true ||
-      displayInAppString === 'true' ||
-      displayInAppString === 'True' ||
-      displayInAppString === 'TRUE' ||
-      displayInAppString === '1' ||
-      displayInAppString === 1;
-    
-    if (isDisplayInApp) {
-      console.log(`✅ Including ${product.item_id} (${product.name}) - cf_display_in_app: ${displayInAppString || displayInAppBoolean}`);
-    }
-    
-    return isDisplayInApp;
-  });
-}
-
-/**
- * Merge inventory products with FIXED commerce images using ID mapping
- */
-function mergeInventoryWithCommerceImages(inventoryProducts, commerceProducts) {
-  console.log(`🔄 Merging ${inventoryProducts.length} inventory with ${commerceProducts.length} commerce products...`);
-  
-  // Create lookup map for commerce products by SKU and name
-  const commerceLookup = new Map();
-  
-  commerceProducts.forEach(commerceProduct => {
-    // Index by SKU (most reliable)
-    if (commerceProduct.sku) {
-      commerceLookup.set(`sku:${commerceProduct.sku.toLowerCase()}`, commerceProduct);
-    }
-    
-    // Index by product name (secondary)
-    if (commerceProduct.product_name || commerceProduct.name) {
-      const name = (commerceProduct.product_name || commerceProduct.name).toLowerCase().trim();
-      commerceLookup.set(`name:${name}`, commerceProduct);
-    }
-    
-    // Index by product ID (if available)
-    if (commerceProduct.product_id) {
-      commerceLookup.set(`id:${commerceProduct.product_id}`, commerceProduct);
-    }
-  });
-
-  const mergedProducts = inventoryProducts.map(inventoryProduct => {
-    let matchedCommerceProduct = null;
-    let matchType = 'no_match';
-
-    // Try to find matching commerce product
-    // 1. Match by SKU (most reliable)
-    if (inventoryProduct.sku) {
-      matchedCommerceProduct = commerceLookup.get(`sku:${inventoryProduct.sku.toLowerCase()}`);
-      if (matchedCommerceProduct) matchType = 'sku_match';
-    }
-
-    // 2. Match by name if SKU match failed
-    if (!matchedCommerceProduct && inventoryProduct.name) {
-      const inventoryName = inventoryProduct.name.toLowerCase().trim();
-      matchedCommerceProduct = commerceLookup.get(`name:${inventoryName}`);
-      if (matchedCommerceProduct) matchType = 'name_match';
-    }
-
-    // Extract FIXED images from matched commerce product
-    let commerceImages = [];
-    if (matchedCommerceProduct && matchedCommerceProduct.product_images) {
-      commerceImages = Array.isArray(matchedCommerceProduct.product_images) 
-        ? matchedCommerceProduct.product_images.filter(img => img && typeof img === 'string' && img.trim() !== '')
-        : [];
-      
-      if (commerceImages.length > 0) {
-        console.log(`✅ Found ${commerceImages.length} FIXED images for ${inventoryProduct.name} (${matchType})`);
-        console.log(`   Source: ${matchedCommerceProduct.image_source || 'unknown'}`);
-        console.log(`   First image: ${commerceImages[0]}`);
-      } else {
-        console.log(`⚠️ No valid images for ${inventoryProduct.name} despite match (${matchType})`);
-      }
-    } else {
-      console.log(`⚠️ No commerce match found for ${inventoryProduct.name}`);
-    }
-
-    return {
-      ...inventoryProduct,
-      // FIXED commerce image data
-      commerce_images: commerceImages,
-      commerce_match_type: matchType,
-      has_commerce_match: !!matchedCommerceProduct,
-      commerce_product_id: matchedCommerceProduct?.product_id || null,
-      image_source: matchedCommerceProduct?.image_source || 'no_source'
-    };
-  });
-
-  // Statistics
-  const withImages = mergedProducts.filter(p => p.commerce_images.length > 0);
-  const skuMatches = mergedProducts.filter(p => p.commerce_match_type === 'sku_match').length;
-  const nameMatches = mergedProducts.filter(p => p.commerce_match_type === 'name_match').length;
-  
-  console.log(`🔄 Merge complete: ${withImages.length}/${mergedProducts.length} products have FIXED images`);
-  console.log(`   📊 SKU matches: ${skuMatches}, Name matches: ${nameMatches}`);
-
-  return mergedProducts;
-}
-
-/**
- * Transform merged products to expected frontend format with FIXED images
- */
-function transformProducts(products) {
-  return products.map(product => {
-    // Use FIXED commerce images (full-size from Storefront API)
-    let productImages = [];
-    
-    if (product.commerce_images && Array.isArray(product.commerce_images) && product.commerce_images.length > 0) {
-      productImages = product.commerce_images; // Already processed by fixed Storefront API
-      console.log(`✅ Using ${productImages.length} FIXED full-size images for ${product.name}`);
-    } else {
-      console.log(`⚠️ No FIXED images found for ${product.name}`);
-    }
-    
-    return {
-      // Use Inventory API field names as primary
-      product_id: product.item_id,
-      product_name: product.name,
-      product_price: product.rate || 0,
-      product_description: product.description || '',
-      
-      // Use the FIXED full-size images from Storefront API
-      product_images: productImages,
-      
-      // Stock/inventory information from Inventory API
-      inventory_count: parseStock(product.stock_on_hand || product.available_stock),
-      
-      // Category information
-      product_category: product.category_name || product.group_name || '',
-      category_id: product.category_id || product.group_id,
-      
-      // Product status and visibility
-      status: product.status,
-      
-      // SEO and URL
-      seo_url: product.sku || product.item_id,
-      
-      // Custom fields (the whole reason we're using Inventory API)
-      cf_display_in_app: product.cf_display_in_app_unformatted || product.cf_display_in_app,
-      
-      // Additional fields
-      sku: product.sku,
-      item_type: product.item_type,
-      product_type: product.product_type,
-      show_in_storefront: product.show_in_storefront,
-      
-      // Pricing details
-      rate: product.rate,
-      purchase_rate: product.purchase_rate,
-      
-      // Stock details
-      stock_on_hand: product.stock_on_hand,
-      available_stock: product.available_stock,
-      reorder_level: product.reorder_level,
-      
-      // Timestamps
-      created_time: product.created_time,
-      last_modified_time: product.last_modified_time,
-      
-      // Debug info (helpful for troubleshooting)
-      has_commerce_images: productImages.length > 0,
-      has_commerce_match: product.has_commerce_match,
-      commerce_product_id: product.commerce_product_id,
-      commerce_match_type: product.commerce_match_type,
-      image_source: product.image_source || 'storefront_api_fixed'
-    };
-  });
-}
-
-/**
- * Parse stock information consistently
- */
-function parseStock(stockValue) {
-  if (stockValue === null || stockValue === undefined || stockValue === '') {
-    return 0;
-  }
-  
-  const parsed = typeof stockValue === 'string' ? 
-    parseFloat(stockValue) : Number(stockValue);
-  return isNaN(parsed) ? 0 : parsed;
-}
-
-/**
- * Generate ENHANCED image statistics for the response
- */
-function generateImageStatistics(products) {
-  const productsWithImages = products.filter(p => p.has_commerce_images && p.product_images.length > 0);
-  const totalImages = products.reduce((sum, p) => sum + (p.product_images?.length || 0), 0);
-  
-  // Analyze image sources
-  const storefrontApiProducts = products.filter(p => p.image_source?.includes('storefront'));
-  const storeApiProducts = products.filter(p => p.image_source?.includes('store_api'));
-  
-  // Analyze match types
-  const skuMatches = products.filter(p => p.commerce_match_type === 'sku_match').length;
-  const nameMatches = products.filter(p => p.commerce_match_type === 'name_match').length;
-
-  return {
-    products_with_images: productsWithImages.length,
-    products_without_images: products.length - productsWithImages.length,
-    total_images_found: totalImages,
-    average_images_per_product: products.length > 0 ? (totalImages / products.length).toFixed(2) : 0,
-    image_success_rate: products.length > 0 ? 
-      ((productsWithImages.length / products.length) * 100).toFixed(1) + '%' : '0%',
-    image_source_breakdown: {
-      storefront_api: storefrontApiProducts.length,
-      store_api_fallback: storeApiProducts.length,
-      no_source: products.filter(p => !p.image_source || p.image_source === 'no_source').length
-    },
-    match_type_breakdown: {
-      sku_matches: skuMatches,
-      name_matches: nameMatches,
-      no_matches: products.length - skuMatches - nameMatches
-    },
-    api_fix_status: 'storefront_integration_active'
-  };
-}

--- a/src/pages/api/sync-products.js
+++ b/src/pages/api/sync-products.js
@@ -1,0 +1,47 @@
+import { productService } from '../../lib/redis-product-service'
+
+export default async function handler(req, res) {
+  const { secret } = req.query
+  if (secret !== process.env.CRON_SECRET) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    console.log('🔄 Manual product sync triggered (Inventory API only)...')
+
+    const result = await productService.syncProducts()
+
+    console.log(`✅ Manual sync completed: ${result.productCount} products`)
+
+    return res.json({
+      success: true,
+      ...result,
+      message: 'Manual sync completed successfully',
+      api_source: 'inventory_only',
+      benefits: [
+        '🚀 No Storefront API calls = No rate limits',
+        '⚡ Faster sync (single API source)',
+        '🖼️ Images from Inventory API work perfectly',
+        '💾 All data cached in Redis for speed',
+      ],
+      instructions: [
+        'Products are now cached in Redis',
+        'Visit /api/products to see cached products',
+        'Visit /api/cache-status to check cache health',
+        'Images served via /api/images/{itemId} proxy',
+      ],
+    })
+  } catch (error) {
+    console.error('❌ Manual product sync failed:', error)
+    return res.status(500).json({
+      error: error.message,
+      success: false,
+      timestamp: new Date().toISOString(),
+    })
+  }
+}
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/sync-products",
+      "schedule": "0 2 * * *"
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- use Zoho Inventory API only with Redis caching
- serve products from cache and add cache status endpoint
- support manual sync via `/api/sync-products?secret=` and scheduled cron job

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt, requires config)*

------
https://chatgpt.com/codex/tasks/task_e_6890c725f44483248810f035c8997a01