### PR TITLE
Fetch and cache inventory image metadata

### DIFF
--- a/src/lib/redis-product-service.js
+++ b/src/lib/redis-product-service.js
@@ -1,0 +1,57 @@
+/**
+ * Simple Redis product service utilities.
+ * Provides helpers to cache image metadata and expose image URLs
+ * for inventory products.
+ */
+
+const PRODUCT_IMAGE = 'PRODUCT_IMAGE';
+
+/**
+ * Cache product image metadata in Redis.
+ * If the product doesn't have a top-level image_id but includes an images array,
+ * fall back to the first image's id when building the cache key.
+ */
+export async function cacheProductImages(redis, product) {
+  if (!redis || !product) return;
+
+  const imageId =
+    product.image_id ||
+    (Array.isArray(product.images) && product.images.length > 0
+      ? product.images[0].image_id
+      : null);
+
+  if (!imageId) return;
+
+  const key = `${PRODUCT_IMAGE}:${product.item_id}`;
+  const value = JSON.stringify({ image_id: imageId });
+  try {
+    await redis.set(key, value);
+  } catch (err) {
+    // Swallow redis errors to avoid breaking product flows
+    console.warn('Failed to cache product image', err);
+  }
+}
+
+/**
+ * Transform raw inventory items into products consumable by the frontend.
+ * Adds product_images with a route to fetch images when any image metadata exists.
+ */
+export function transformInventoryProducts(items = []) {
+  return items.map(item => {
+    const product = { ...item, product_images: item.product_images || [] };
+
+    if (
+      item.image_id ||
+      (Array.isArray(item.images) && item.images.length > 0)
+    ) {
+      product.product_images.push(`/api/images/${item.item_id}`);
+    }
+
+    return product;
+  });
+}
+
+export default {
+  cacheProductImages,
+  transformInventoryProducts,
+};

--- a/src/lib/zoho-api-inventory.ts
+++ b/src/lib/zoho-api-inventory.ts
@@ -152,22 +152,36 @@ class ZohoInventoryAPI {
   async getInventoryProducts(): Promise<ZohoInventoryItem[]> {
     try {
       console.log('📦 Fetching products from Zoho Inventory API...');
-      
-      const response = await this.apiRequest('/items');
+
+      let response;
+
+      try {
+        // Primary request including custom fields and image metadata
+        response = await this.apiRequest(
+          '/items?custom_fields=true&include=images,documents'
+        );
+      } catch (primaryError) {
+        console.warn(
+          '⚠️ Inventory API custom field fetch failed, retrying without custom fields...'
+        );
+        // Fallback request without custom fields but still including image metadata
+        response = await this.apiRequest('/items?include=images,documents');
+      }
+
       const items = response.items || [];
-      
+
       console.log(`📊 Retrieved ${items.length} items from Inventory API`);
-      
+
       // Log custom fields info for debugging
-      const itemsWithCustomFields = items.filter((item: ZohoInventoryItem) => 
+      const itemsWithCustomFields = items.filter((item: ZohoInventoryItem) =>
         item.custom_fields && item.custom_fields.length > 0
       );
       console.log(`🏷️  ${itemsWithCustomFields.length} items have custom fields`);
-      
+
       return items;
     } catch (error) {
       console.error('❌ Failed to get inventory products:', error);
-      
+
       // Provide helpful error context
       if (error instanceof Error) {
         if (error.message.includes('rate limit')) {
@@ -180,7 +194,7 @@ class ZohoInventoryAPI {
           throw new Error('Zoho authentication failed. Check OAuth credentials.');
         }
       }
-      
+
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- request inventory items with custom fields and image metadata with fallback
- cache image metadata for inventory products using image list when needed
- expose cached inventory images to frontend via API path

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_6890d55daa1c8324b8377a4cd816b99b