### PR TITLE
Use CDN for Zoho storefront images

### DIFF
--- a/src/lib/zoho-api.ts
+++ b/src/lib/zoho-api.ts
@@ -214,9 +214,9 @@ class ZohoCommerceAPI {
     const addImages = (items: any[]) => {
       items.forEach(item => {
         if (typeof item === 'string') {
-          imageSet.add(`https://commerce.zoho.com${item}`);
+          imageSet.add(`https://us.zohocommercecdn.com${item}?storefront_domain=www.traveldatawifi.com`);
         } else if (item?.url) {
-          imageSet.add(`https://commerce.zoho.com${item.url}`);
+          imageSet.add(`https://us.zohocommercecdn.com${item.url}?storefront_domain=www.traveldatawifi.com`);
         }
       });
     };


### PR DESCRIPTION
## Summary
- Load product and variant images via `us.zohocommercecdn.com` with `storefront_domain` parameter for anonymous access
- Ensure document images also use CDN host with `storefront_domain` query string

## Testing
- `npm run lint` *(fails: asks for ESLint configuration)*
- `curl -I https://us.zohocommercecdn.com/product-images/no-image.png?storefront_domain=www.traveldatawifi.com` *(HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890eae4e1508324af30bb8c1299824e