### PR TITLE
feat: add kv redis client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ===== README.md =====
 # Travel Data WiFi - Jamstack E-commerce
 
-A modern, high-performance e-commerce site built with Next.js, Cloudflare Pages, and Zoho Commerce APIs.
+A modern, high-performance e-commerce site built with Next.js, Vercel, and Zoho Commerce APIs.
 
 ## Features
 
@@ -9,7 +9,7 @@ A modern, high-performance e-commerce site built with Next.js, Cloudflare Pages,
 - 🛒 **E-commerce functionality** powered by Zoho APIs
 - 📱 **Mobile-first responsive design**
 - 🔍 **SEO optimized** with structured data
-- 🛡️ **Secure and fast** with Cloudflare Pages
+- 🛡️ **Secure and fast** with Vercel
 - 🎨 **Modern UI** with Tailwind CSS
 
 ## Quick Start
@@ -29,16 +29,20 @@ ZOHO_CLIENT_ID=your_zoho_client_id
 ZOHO_CLIENT_SECRET=your_zoho_client_secret  
 ZOHO_REFRESH_TOKEN=your_zoho_refresh_token
 ZOHO_STORE_ID=your_zoho_store_id
+KV_URL=your_kv_url
+KV_REST_API_URL=your_kv_rest_api_url
+KV_REST_API_TOKEN=your_kv_rest_api_token
+KV_REST_API_READ_ONLY_TOKEN=your_kv_read_only_token
+REDIS_URL=your_redis_url
 ```
 
 ## Deployment
 
-This project is optimized for Cloudflare Pages:
+This project is deployed on Vercel:
 
-1. Connect your GitHub repository to Cloudflare Pages
+1. Connect your GitHub repository to Vercel
 2. Set build command: `npm run build`
-3. Set output directory: `out`
-4. Add environment variables in Cloudflare Pages dashboard
+3. Add environment variables in the Vercel dashboard
 
 ## Project Structure
 
@@ -56,7 +60,7 @@ src/
 - Static generation with ISR for product updates
 - Image optimization and lazy loading
 - Code splitting and tree shaking
-- CDN-first architecture with Cloudflare
+- CDN-first architecture with Vercel
 
 ## SEO Features
 

--- a/package.json
+++ b/package.json
@@ -10,23 +10,23 @@
     "export": "next export"
   },
   "dependencies": {
+    "@stripe/react-stripe-js": "^2.4.0",
+    "@stripe/stripe-js": "^2.4.0",
+    "@upstash/redis": "^1.35.3",
+    "@vercel/analytics": "^1.1.1",
+    "axios": "^1.6.2",
+    "clsx": "^2.0.0",
+    "lucide-react": "^0.294.0",
     "next": "14.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "stripe": "^14.9.0",
-    "@stripe/stripe-js": "^2.4.0",
-    "@stripe/react-stripe-js": "^2.4.0",
-    "axios": "^1.6.2",
-    "swr": "^2.2.4",
-    "zustand": "^4.4.7",
     "react-hot-toast": "^2.4.1",
-    "lucide-react": "^0.294.0",
-    "clsx": "^2.0.0",
+    "stripe": "^14.9.0",
+    "swr": "^2.2.4",
     "tailwind-merge": "^2.0.0",
-    "@vercel/analytics": "^1.1.1"
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
-    "typescript": "^5.3.2",
     "@types/node": "^20.9.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
@@ -34,6 +34,7 @@
     "eslint": "^8.53.0",
     "eslint-config-next": "14.0.3",
     "postcss": "^8.4.31",
-    "tailwindcss": "^3.3.6"
+    "tailwindcss": "^3.3.6",
+    "typescript": "^5.3.2"
   }
 }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,0 +1,23 @@
+import { Redis } from '@upstash/redis';
+
+const redis = new Redis({
+  url: process.env.KV_REST_API_URL!,
+  token: process.env.KV_REST_API_TOKEN!,
+});
+
+const redisReadOnly = process.env.KV_REST_API_READ_ONLY_TOKEN
+  ? new Redis({
+      url: process.env.KV_REST_API_URL!,
+      token: process.env.KV_REST_API_READ_ONLY_TOKEN!,
+    })
+  : redis;
+
+export async function get<T>(key: string): Promise<T | null> {
+  return redisReadOnly.get<T>(key);
+}
+
+export async function set<T>(key: string, value: T): Promise<string | null> {
+  return (await redis.set(key, value)) as string | null;
+}
+
+export { redis };


### PR DESCRIPTION
## Summary
- switch Redis helper to Vercel KV env vars with optional read-only client
- document KV environment variables and Vercel deployment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689101f4d5c08324bb590cce6e39e089